### PR TITLE
Update Fedora installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Packages currently exist for:
   * Ubuntu 18.04 (Bionic Beaver)
   * Ubuntu 19.04 (Disco Dingo)
 
+### In official repositories:
+
+- [Fedora (30+)](https://apps.fedoraproject.org/packages/cawbird): `sudo dnf install cawbird`
+
 The following distros should be supported in future:
 
 * Ubuntu


### PR DESCRIPTION
Packaged for Fedora and now in official repos. Please update installation info. Now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2019-5d4bbac59a).