### PR TITLE
add NixOS package to list of supported distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The following distros currently have their own official packages:
 
 * [Fedora (30+)](https://apps.fedoraproject.org/packages/cawbird)
   * `sudo dnf install cawbird`
+* [NixOS (19.09+)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/cawbird/default.nix)
+  * `nix-shell -p cawbird` for testing, `nix-env -iA cawbird` for permanent installation
+  * the [Nix package manager](https://nixos.org/nix/) can also be used in other distributions for running Cawbird
 
 ### Dependencies
 


### PR DESCRIPTION
Since the 19.09 release, cawbird is now included in the official NixOS nixpkgs repository.