### PR TITLE
Bug164 zero scroll delta

### DIFF
--- a/src/TweetInfoPage.vala
+++ b/src/TweetInfoPage.vala
@@ -160,7 +160,18 @@ class TweetInfoPage : IPage, ScrollWidget, Cb.MessageReceiver {
     mm_widget.media_clicked.connect ((m, i) => TweetUtils.handle_media_click (tweet.get_medias (), main_window, i));
     this.scroll_event.connect ((evt) => {
       double evt_delta_x, evt_delta_y;
-      evt.get_scroll_deltas(out evt_delta_x, out evt_delta_y);
+      var success = evt.get_scroll_deltas(out evt_delta_x, out evt_delta_y);
+
+      if (!success) {
+        Gdk.ScrollDirection scroll_dir;
+        success = evt.get_scroll_direction(out scroll_dir);
+
+        if (success && scroll_dir == Gdk.ScrollDirection.UP) {
+          evt_delta_y = -1;
+        } else {
+          evt_delta_y = 0;
+        }
+      }
 
       if (evt_delta_y < 0 && this.vadjustment.value == 0 && tweet.is_reply()) {
         int inc = (int)(vadjustment.step_increment * (-evt_delta_y));

--- a/src/TweetInfoPage.vala
+++ b/src/TweetInfoPage.vala
@@ -159,8 +159,11 @@ class TweetInfoPage : IPage, ScrollWidget, Cb.MessageReceiver {
 
     mm_widget.media_clicked.connect ((m, i) => TweetUtils.handle_media_click (tweet.get_medias (), main_window, i));
     this.scroll_event.connect ((evt) => {
-      if (evt.delta_y < 0 && this.vadjustment.value == 0 && tweet.is_reply()) {
-        int inc = (int)(vadjustment.step_increment * (-evt.delta_y));
+      double evt_delta_x, evt_delta_y;
+      evt.get_scroll_deltas(out evt_delta_x, out evt_delta_y);
+
+      if (evt_delta_y < 0 && this.vadjustment.value == 0 && tweet.is_reply()) {
+        int inc = (int)(vadjustment.step_increment * (-evt_delta_y));
         max_size_container.max_size += inc;
         return true;
       }


### PR DESCRIPTION
Fix for an odd fvwm situation where the `delta_y` value is always zero and so users can't scroll up a thread.

Presumably there are more setups that do this, but we're not quite sure what causes it. The important thing is that this fixes it!