### PR TITLE
Add rest API to resolve problems with flatpak-builder

### DIFF
--- a/flatpak/uk.co.ibboard.cawbird.json
+++ b/flatpak/uk.co.ibboard.cawbird.json
@@ -49,6 +49,16 @@
       ]
     },
     {
+      "name":"rest",
+      "sources":[
+        {
+          "type":"archive",
+          "url":"https://download.gnome.org/sources/rest/0.7/rest-0.7.93.tar.xz",
+          "sha256":"c710644455340a44ddc005c645c466f05c0d779993138ea21a62c6082108b216"
+        }
+      ]
+    },
+    {
       "name":"gspell",
       "config-opts":[
         "--enable-vala=yes"


### PR DESCRIPTION
Currently flatpak-builder can't build Cawbird, as the dependency for librest is not declared as a module in the manifest.
This PR adds the module so it can be build.