### PR TITLE
Detach signal handler when receiver is finalized

### DIFF
--- a/src/CbMediaImageWidget.c
+++ b/src/CbMediaImageWidget.c
@@ -28,6 +28,10 @@ cb_media_image_widget_finalize (GObject *object)
     cairo_surface_destroy(self->image_surface);
   }
 
+  if (self->media && self->hires_progress_id) {
+    g_signal_handler_disconnect (self->media, self->hires_progress_id);
+  }
+
   G_OBJECT_CLASS (cb_media_image_widget_parent_class)->finalize (object);
 }
 
@@ -122,7 +126,8 @@ cb_media_image_widget_new (CbMedia *media, GdkRectangle *max_dimensions)
   else {
     double scale_width = media->width * 1.0 / media->thumb_width;
     double scale_height = media->height * 1.0 / media->thumb_height;
-    g_signal_connect(media, "hires-progress", G_CALLBACK(hires_progress), self);
+    self->media = media;
+    self->hires_progress_id = g_signal_connect(media, "hires-progress", G_CALLBACK(hires_progress), self);
     self->image_surface = cairo_image_surface_create(cairo_image_surface_get_format(media->surface), media->width, media->height);
     cairo_t *ct = cairo_create(self->image_surface);
     cairo_scale(ct, scale_width, scale_height);

--- a/src/CbMediaImageWidget.h
+++ b/src/CbMediaImageWidget.h
@@ -39,6 +39,9 @@ struct _CbMediaImageWidget
 
   gulong hadj_changed_id;
   gulong vadj_changed_id;
+
+  CbMedia *media;
+  gulong hires_progress_id;
 };
 typedef struct _CbMediaImageWidget CbMediaImageWidget;
 

--- a/src/CbMediaImageWidget.h
+++ b/src/CbMediaImageWidget.h
@@ -37,9 +37,6 @@ struct _CbMediaImageWidget
   double drag_start_hvalue;
   double drag_start_vvalue;
 
-  gulong hadj_changed_id;
-  gulong vadj_changed_id;
-
   CbMedia *media;
   gulong hires_progress_id;
 };


### PR DESCRIPTION
Previously, it was possible for the `hires_progress` callback to be called after the associated `CbMediaImageWidget` had already been finalized, since the handler is only automatically disconnected when the emitter (the `CbMedia`) is finalized. Track the handler ID and also the `CbMedia` inside the `CbMediaImageWidget`, so that the handler can be disconnected in the finalizer if it had been connected before.

Fixes #196.

Also, remove two unused struct fields.