### PR TITLE
Don’t crash if Twitter error is not valid JSON

### DIFF
--- a/src/util/TweetUtils.vala
+++ b/src/util/TweetUtils.vala
@@ -57,7 +57,11 @@ namespace TweetUtils {
        */
       var parser = new Json.Parser();
       parser.load_from_data (json);
-      var obj = parser.get_root().get_object();
+      var node = parser.get_root();
+      if (node == null) {
+          return new GLib.Error (get_error_domain(), 0, "Twitter error is not valid JSON: %s", json);
+      }
+      var obj = node.get_object();
       var errors = obj.get_array_member("errors");
       // Assume there's always at least one, and we just take the first
       var error = errors.get_element(0).get_object();


### PR DESCRIPTION
If we can’t parse the error response from JSON, make `failed_request_to_error()` return a custom error instead of null, which previously caused a segfault afterwards.

Fixes #200.