### PR TITLE
README.md: Add note about Alpine Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ i586, x86_64 (amd64) and aarch64 (arm64) are available on most platforms (where 
 
 The following distros currently have their own official packages:
 
+* [Alpine Linux / postmarketOS (Edge)](https://pkgs.alpinelinux.org/packages?name=cawbird&branch=edge)
+  * `sudo apk add cawbird`
 * [Fedora (30+)](https://apps.fedoraproject.org/packages/cawbird)
   * `sudo dnf install cawbird`
 * [NixOS (19.09+)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/cawbird/default.nix)


### PR DESCRIPTION
Cawbird is available in Alpine Linux (and as such postmarketOS) Edge, so let's note this here as well. I added it first as the current items seem to be in alphabetical order so I decided I'd keep that.