### PR TITLE
Correct fix for #122 to recenter changing media

### DIFF
--- a/src/window/MediaDialog.vala
+++ b/src/window/MediaDialog.vala
@@ -101,6 +101,7 @@ class MediaDialog : Gtk.Window {
     // TRANSLATORS: Values are current image index (1-based) and total image count. Pluralisation is based on total image count.
     // Should only be seen when image count is two or more.
     media_count.set_text(ngettext("Image %d of %d", "Image %d of %d", this.media.length).printf(cur_index + 1, this.media.length));
+    this.set_position(Gtk.WindowPosition.CENTER_ALWAYS);
   }
 
   private void next_media () {


### PR DESCRIPTION
Tested this fix and it works correctly compared to the previous fix which used Gtk.WindowPosition.CENTER_ON_PARENT and was reverted due to #271.