### PR TITLE
Retry media downloads once

### DIFF
--- a/src/CbMediaDownloader.c
+++ b/src/CbMediaDownloader.c
@@ -401,10 +401,19 @@ cb_media_downloader_load_threaded (CbMediaDownloader *downloader,
                   G_CALLBACK(update_media_progress), cancellable, &error, media);  
 
   if (error) {
-    g_warning ("Couldn't load pixbuf: %s (%s)", error->message, download_url);
-    mark_invalid (media);
+    g_info ("Couldn't load pixbuf, retrying: %s (%s)", error->message, download_url);
     g_error_free (error);
-    return;
+
+    load_media_url (download_url, task_data, &media->surface, &media->animation,
+                    media->consumer_key, media->consumer_secret, media->token, media->token_secret,
+                    G_CALLBACK(update_media_progress), cancellable, &error, media);
+
+    if (error) {
+      g_warning ("Couldn't load pixbuf: %s (%s)", error->message, download_url);
+      mark_invalid (media);
+      g_error_free (error);
+      return;
+    }
   }
 
   cb_media_loading_finished (media);


### PR DESCRIPTION
I’ve been having a lot of issues with media not loading – “SSL handshake failed”, according to the journal. Let’s retry downloads once and see if that helps.

---

Seems to help locally. Submitting it for consideration, I suppose – if these issues are limited to me then this probably doesn’t need to be merged upstream :)