### PR TITLE
Improve speed of repaint on focus/unfocus

### DIFF
--- a/src/DefaultTimeline.vala
+++ b/src/DefaultTimeline.vala
@@ -35,6 +35,7 @@ public abstract class DefaultTimeline : ScrollWidget, IPage {
   public unowned MainWindow window  {
     set {
       main_window = value;
+      tweet_list.main_window = main_window;
     }
   }
   public TweetListBox tweet_list = new TweetListBox ();

--- a/src/ListStatusesPage.vala
+++ b/src/ListStatusesPage.vala
@@ -33,6 +33,7 @@ class ListStatusesPage : ScrollWidget, Cb.MessageReceiver, IPage {
   public unowned MainWindow window {
     set {
       main_window = value;
+      tweet_list.main_window = main_window;
     }
   }
   public unowned Account account;

--- a/src/MainWidget.vala
+++ b/src/MainWidget.vala
@@ -56,10 +56,16 @@ public class MainWidget : Gtk.Box {
     stack.notify["transition-running"].connect(() => {
       if (stack.transition_running == false) {
         var visible_child = stack.visible_child;
-        stack.get_children().foreach((w) => { if (w != visible_child) { stack.remove(w); }});
+        stack.get_children().foreach((w) => {
+          if (w != visible_child && w != stack_impostor) {
+           stack.remove(w); 
+          }
+        });
       }
     });
     this.add (stack);
+
+    stack.add (stack_impostor);
 
     pages     = new IPage[11];
     pages[0]  = new HomeTimeline (Page.STREAM, account);
@@ -150,9 +156,6 @@ public class MainWidget : Gtk.Box {
       stack_impostor.clone (page);
       var transition_type = stack.transition_type;
       stack.transition_type = Gtk.StackTransitionType.NONE;
-      if (stack_impostor.parent == null) {
-        stack.add(stack_impostor);
-      }
       stack.set_visible_child (stack_impostor);
       stack.transition_type = transition_type;
       stack.remove(page);

--- a/src/MainWidget.vala
+++ b/src/MainWidget.vala
@@ -53,6 +53,12 @@ public class MainWidget : Gtk.Box {
     this.stack = new Gtk.Stack ();
     stack.set_hexpand (true);
     stack.set_vexpand (true);
+    stack.notify["transition-running"].connect(() => {
+      if (stack.transition_running == false) {
+        var visible_child = stack.visible_child;
+        stack.get_children().foreach((w) => { if (w != visible_child) { w.hide(); }});
+      }
+    });
     this.add (stack);
 
     stack.add (stack_impostor);
@@ -171,7 +177,8 @@ public class MainWidget : Gtk.Box {
     /* on_join first, then set_visible_child so the new page is still !child-visible,
        so e.g. GtkStack transitions inside the page aren't animated */
     page.on_join (page_id, args);
-    stack.set_visible_child (pages[page_id]);
+    page.show();
+    stack.set_visible_child (page);
     ((MainWindow)this.parent).set_window_title (page.get_title (), stack.transition_type);
 
     page_switch_lock = false;

--- a/src/ProfilePage.vala
+++ b/src/ProfilePage.vala
@@ -35,6 +35,9 @@ class ProfilePage : ScrollWidget, IPage, Cb.MessageReceiver {
     set {
       main_window = value;
       user_lists.main_window = value;
+      tweet_list.main_window = main_window;
+      followers_list.main_window = main_window;
+      followers_list.main_window = main_window;
     }
   }
   public unowned Account account;

--- a/src/SearchPage.vala
+++ b/src/SearchPage.vala
@@ -29,6 +29,7 @@ class SearchPage : IPage, Cb.MessageReceiver, Gtk.Box {
   public unowned MainWindow window {
     set {
       main_window = value;
+      tweet_list.main_window = main_window;
     }
   }
 

--- a/src/TweetInfoPage.vala
+++ b/src/TweetInfoPage.vala
@@ -38,6 +38,10 @@ class TweetInfoPage : IPage, ScrollWidget, Cb.MessageReceiver {
   public unowned MainWindow window {
     set {
       main_window = value;
+      replied_to_list_box.main_window = main_window;
+      replies_list_box.main_window = main_window;
+      self_replies_list_box.main_window = main_window;
+      mentioned_replies_list_box.main_window = main_window;
     }
   }
   public unowned Account account;

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -177,6 +177,14 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
                                  tweet.get_user_id () != account.id);
 
     favorite_button.active = tweet.is_flag_set (Cb.TweetState.FAVORITED);
+    retweet_button.size_allocate.connect_after(() => {
+      // XXX: Grab focus after the button is show (if it has a size) to avoid
+      // grabbing focus before the widget is ready (which jumps us
+      // to the top of the list)
+      if (retweet_button.get_allocated_width() > 1) {
+        retweet_button.grab_focus();
+      }
+    });
 
     tweet.state_changed.connect (state_changed_cb);
 
@@ -661,7 +669,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
       action_box.show();
       grid.hide();
       this.activatable = false;
-      retweet_button.grab_focus();
     }
   }
 

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -178,10 +178,18 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
 
     favorite_button.active = tweet.is_flag_set (Cb.TweetState.FAVORITED);
     retweet_button.size_allocate.connect_after(() => {
-      // XXX: Grab focus after the button is show (if it has a size) to avoid
+      // XXX: Grab focus after the button is allocated (if it has a size) to avoid
       // grabbing focus before the widget is ready (which jumps us
       // to the top of the list)
-      if (retweet_button.get_allocated_width() > 1) {
+      if (retweet_button.visible && retweet_button.get_allocated_width() > 1) {
+        retweet_button.grab_focus();
+      }
+    });
+    grab_focus.connect_after(() => {
+      // XXX: Also grab focus when the list item gets focus
+      // because the size_allocate doesn't re-trigger when re-showing
+      // the button
+      if (action_box.visible && retweet_button.get_allocated_width() > 1) {
         retweet_button.grab_focus();
       }
     });
@@ -660,7 +668,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
       grid.show();
       action_box.hide();
       this.activatable = true;
-      this.grab_focus();
     } else {
       // We can't use size groups because they only work when all elements are visible
       // So kludge an approximation with set_size_request on the action box (which will always be the shortest widget)
@@ -670,6 +677,7 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
       grid.hide();
       this.activatable = false;
     }
+    this.grab_focus();
   }
 
 

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -44,8 +44,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
   [GtkChild]
   private Gtk.Grid grid;
   [GtkChild]
-  private Gtk.Stack stack;
-  [GtkChild]
   private Gtk.Box action_box;
   [GtkChild]
   private Gtk.Label reply_label;
@@ -78,7 +76,7 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
   }
   public bool shows_actions {
     get {
-      return stack.visible_child == action_box;
+      return action_box.visible;
     }
   }
   private unowned Account account;
@@ -579,7 +577,8 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
 
     if (tweet.is_flag_set (Cb.TweetState.DELETED)) {
       this.sensitive = false;
-      stack.visible_child = grid;
+      grid.show();
+      action_box.hide();
     }
 
     this.values_set = true;
@@ -649,12 +648,19 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
     if (this._read_only)
       return;
 
-    if (stack.visible_child == action_box) {
-      stack.visible_child = grid;
+    if (action_box.visible) {
+      grid.show();
+      action_box.hide();
       this.activatable = true;
       this.grab_focus();
     } else {
-      stack.visible_child = action_box;
+      // We can't use size groups because they only work when all elements are visible
+      // So kludge an approximation with set_size_request on the action box (which will always be the shortest widget)
+      // XXX: Currently doesn't take into account changes in grid height while grid is hidden
+      var grid_height = grid.get_allocated_height() + grid.get_margin_top() + grid.get_margin_bottom();
+      action_box.set_size_request(-1, grid_height);
+      action_box.show();
+      grid.hide();
       this.activatable = false;
       retweet_button.grab_focus();
     }

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -656,7 +656,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
     } else {
       // We can't use size groups because they only work when all elements are visible
       // So kludge an approximation with set_size_request on the action box (which will always be the shortest widget)
-      // XXX: Currently doesn't take into account changes in grid height while grid is hidden
       var grid_height = grid.get_allocated_height() + grid.get_margin_top() + grid.get_margin_bottom();
       action_box.set_size_request(-1, grid_height);
       action_box.show();
@@ -853,7 +852,14 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
   }
 
   public override void size_allocate(Gtk.Allocation allocation) {
-    if ((allocation.width < Cawbird.RESPONSIVE_LIMIT) != (get_allocated_width() < Cawbird.RESPONSIVE_LIMIT) || get_allocated_width() <= 1) {
+    var current_width = get_allocated_width();
+
+    if (shows_actions && current_width != allocation.width) {
+      // The grid widget controls our height, but we can't get it right unless it is visible
+      toggle_mode();
+    }
+
+    if ((allocation.width < Cawbird.RESPONSIVE_LIMIT) != (current_width < Cawbird.RESPONSIVE_LIMIT) || current_width <= 1) {
       // We've crossed the threshold, so reallocate as appropriate
       if (allocation.width < Cawbird.RESPONSIVE_LIMIT) {
         grid.child_set (avatar_image, "height", 2);

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -852,16 +852,20 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
   }
 
   public override void size_allocate(Gtk.Allocation allocation) {
-    var current_width = get_allocated_width();
+    var cur_width = get_allocated_width();
+    var new_width = allocation.width;
 
-    if (shows_actions && current_width != allocation.width) {
+    if (shows_actions && cur_width != new_width) {
       // The grid widget controls our height, but we can't get it right unless it is visible
       toggle_mode();
     }
 
-    if ((allocation.width < Cawbird.RESPONSIVE_LIMIT) != (current_width < Cawbird.RESPONSIVE_LIMIT) || current_width <= 1) {
+    var new_size_is_responsive = new_width < Cawbird.RESPONSIVE_LIMIT;
+    var cur_size_is_responsive = cur_width < Cawbird.RESPONSIVE_LIMIT;
+
+    if (new_size_is_responsive != cur_size_is_responsive || cur_width <= 1) {
       // We've crossed the threshold, so reallocate as appropriate
-      if (allocation.width < Cawbird.RESPONSIVE_LIMIT) {
+      if (new_size_is_responsive) {
         grid.child_set (avatar_image, "height", 2);
         grid.child_set (scroller, "left-attach", 0);
         grid.child_set (scroller, "width", 7);

--- a/src/widgets/TweetListBox.vala
+++ b/src/widgets/TweetListBox.vala
@@ -26,6 +26,7 @@ public class TweetListBox : ListBox {
       return _action_entry;
     }
   }
+  public MainWindow main_window { private get; set; }
 
   public TweetListBox () {
   }
@@ -48,7 +49,7 @@ public class TweetListBox : ListBox {
     assert (obj is Cb.Tweet);
 
     var row = new TweetListEntry ((Cb.Tweet) obj,
-                                  (MainWindow) get_toplevel (),
+                                  main_window,
                                   this.account);
     row.fade_in ();
     return row;

--- a/ui/tweet-info-page.ui
+++ b/ui/tweet-info-page.ui
@@ -30,6 +30,7 @@
                 <child>
                   <object class="GtkLabel" id="missing_tweet_label">
                     <property name="visible">0</property>
+                    <property name="no-show-all">1</property>
                     <property name="margin-top">18</property>
                     <property name="margin-bottom">18</property>
                     <property name="margin-start">6</property>
@@ -41,6 +42,7 @@
                 <child>
                   <object class="TweetListBox" id="replied_to_list_box">
                     <property name="visible">0</property>
+                    <property name="no-show-all">1</property>
                     <property name="can-focus">False</property>
                     <property name="selection-mode">none</property>
                   </object>
@@ -439,21 +441,24 @@
 
                 <child>
                   <object class="TweetListBox" id="self_replies_list_box">
-                    <property name="visible">1</property>
+                    <property name="visible">0</property>
+                    <property name="no-show-all">1</property>
                     <property name="selection-mode">none</property>
                     <property name="hexpand">1</property>
                   </object>
                 </child>
                 <child>
                   <object class="TweetListBox" id="mentioned_replies_list_box">
-                    <property name="visible">1</property>
+                    <property name="visible">0</property>
+                    <property name="no-show-all">1</property>
                     <property name="selection-mode">none</property>
                     <property name="hexpand">1</property>
                   </object>
                 </child>
                 <child>
                   <object class="TweetListBox" id="replies_list_box">
-                    <property name="visible">1</property>
+                    <property name="visible">0</property>
+                    <property name="no-show-all">1</property>
                     <property name="selection-mode">none</property>
                     <property name="hexpand">1</property>
                   </object>

--- a/ui/tweet-list-entry.ui
+++ b/ui/tweet-list-entry.ui
@@ -28,15 +28,15 @@
     <signal name="focus-out-event" handler="focus_out_cb"/>
     <signal name="key-release-event" handler="key_released_cb"/>
     <child>
-      <object class="GtkStack" id="stack">
+      <object class="GtkBox" id="stack">
         <property name="visible">1</property>
-        <property name="visible-child">grid</property>
-        <property name="transition-type">crossfade</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="action_box">
-            <property name="visible">1</property>
+            <property name="visible">0</property>
             <property name="spacing">12</property>
             <property name="halign">center</property>
+            <property name="vexpand">true</property>
             <child>
               <object class="DoubleTapButton" id="retweet_button">
                 <property name="visible">true</property>


### PR DESCRIPTION
GTK invalidates *all* GTK/CSS nodes when unfocusing refocusing. This is made worse by stacks, which are available (and invalidated) even when not the top item in the stack.

By dropping stacks and doing some other shuffles instead we seem to improve performance.