### PR TITLE
Add 'Guix' to official distro repositories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following distros currently have their own official packages:
   * `pacman -Syu cawbird`
 * [Fedora (30+)](https://apps.fedoraproject.org/packages/cawbird)
   * `sudo dnf install cawbird`
+* [Guix](https://guix.gnu.org/en/packages/cawbird-1.4.1/)
+  * `guix install cawbird`
 * [NixOS (19.09+)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/cawbird/default.nix)
   * `nix-shell -p cawbird` for testing, `nix-env -iA cawbird` for permanent installation
 * [Solus](https://dev.getsol.us/source/cawbird/)


### PR DESCRIPTION
Hello Folks,

I have packaged Cawbird into [Guix](https://guix.gnu.org).

This PR is to update README file to mention installation via Guix.

Regards,
RG.