### PR TITLE
Dirs: create user config dir if it doesn't exist

### DIFF
--- a/src/util/Dirs.vala
+++ b/src/util/Dirs.vala
@@ -43,7 +43,9 @@ namespace Dirs {
   private string _config (string app_name) {
     string dir = GLib.Environment.get_home_dir () + "/." + app_name + "/";
     if (!GLib.FileUtils.test (dir, GLib.FileTest.EXISTS)) {
-      dir = GLib.Environment.get_user_config_dir () + "/" + app_name + "/";
+      string user_config_dir = GLib.Environment.get_user_config_dir ();
+      create_folder (user_config_dir);
+      dir = user_config_dir + "/" + app_name + "/";
     }
     return dir;
   }


### PR DESCRIPTION
Cawbird assumes the user config dir (usually `~/.config`) always exists,
which might not be the case, especialy for sandboxed or other
container-based environments. This leads to an error when trying to
create the app config dir.

In order to avoid such problems, ensure the user config dir exists
before trying to create app config dir.

See [Debian CI logs](https://ci.debian.net/data/autopkgtest/testing/amd64/c/cawbird/19185511/log.gz) for an example of such a failure.