### PR TITLE
Reload button with single click activate

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,6 +153,7 @@ cawbird_lib_sources = files([
   'src/widgets/LazyMenuButton.vala',
   'src/widgets/ListBox.vala',
   'src/widgets/MediaButton.vala',
+  'src/widgets/MediaButtonSurface.vala',
   'src/widgets/MultiMediaWidget.vala',
   'src/widgets/PixbufButton.vala',
   'src/widgets/ResizableImage.vala',

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -30,6 +30,7 @@ src/widgets/FavImageView.vala
 src/widgets/FollowButton.vala
 src/widgets/ListBox.vala
 src/widgets/MediaButton.vala
+src/widgets/MediaButtonSurface.vala
 src/widgets/PixbufButton.vala
 src/widgets/TweetListBox.vala
 src/window/AccountDialog.vala

--- a/src/CbMedia.c
+++ b/src/CbMedia.c
@@ -176,17 +176,6 @@ cb_media_loading_finished (CbMedia *media)
   media->thumb_width   = cairo_image_surface_get_width(media->surface);
   media->thumb_height  = cairo_image_surface_get_height(media->surface);
 
-  // Take these sizes as full size if full size isn't set.
-  // This happens when loading third-party images which don't have
-  // Twitter's scaling variants.
-  if (media->width == -1) {
-    media->width = media->thumb_width;
-  }
-
-  if (media->height == -1) {
-    media->height = media->thumb_height;
-  }
-
   media->invalid = FALSE;
   media->loaded = TRUE;
   media->loading = FALSE;
@@ -195,6 +184,8 @@ cb_media_loading_finished (CbMedia *media)
     // There is no higher res to load so pretend we did.
     // The get_highest_res_surface() function then deals with what is available
     media->loaded_hires = TRUE;
+    media->width = media->thumb_width;
+    media->width = media->thumb_width;
   }
   else if (cb_media_is_video (media)) {
     // Video doesn't have a hires, it runs the URL through GStreamer, so pretend we loaded the hires image
@@ -245,6 +236,11 @@ void
 cb_media_loading_hires_finished (CbMedia *media)
 {
   g_return_if_fail (CB_IS_MEDIA (media));
+
+  if (media->surface_hires) {
+    media->width   = cairo_image_surface_get_width(media->surface_hires);
+    media->height  = cairo_image_surface_get_height(media->surface_hires);
+  }
 
   media->loaded_hires = TRUE;
   media->loading_hires = FALSE;

--- a/src/CbMedia.c
+++ b/src/CbMedia.c
@@ -191,7 +191,7 @@ cb_media_loading_finished (CbMedia *media)
   media->loaded = TRUE;
   media->loading = FALSE;
 
-  if (media->height == media->thumb_height && media->width == media->thumb_width) {
+  if (media->url != NULL && media->thumb_url != NULL && g_strcmp0(media->url, media->thumb_url) == 0) {
     // There is no higher res to load so pretend we did.
     // The get_highest_res_surface() function then deals with what is available
     media->loaded_hires = TRUE;

--- a/src/CbMedia.h
+++ b/src/CbMedia.h
@@ -60,6 +60,7 @@ struct _CbMedia
   guint loading_hires: 1;
   guint loaded_hires : 1;
   guint invalid : 1;
+  guint permanent_invalid : 1;
   double percent_loaded;
   double percent_loaded_hires;
 

--- a/src/CbMediaDownloader.c
+++ b/src/CbMediaDownloader.c
@@ -472,9 +472,6 @@ cb_media_downloader_load_hires_threaded (CbMediaDownloader *downloader,
     return;
   }
 
-  media->width = cairo_image_surface_get_width(media->surface_hires);
-  media->height = cairo_image_surface_get_height(media->surface_hires);
-
   cb_media_loading_hires_finished (media);
 }
 

--- a/src/CbMediaDownloader.c
+++ b/src/CbMediaDownloader.c
@@ -457,6 +457,7 @@ void cb_media_downloader_reload_async (CbMediaDownloader   *downloader,
 {
   g_return_if_fail (media->invalid);
   media->loaded = FALSE;
+  media->loaded_hires = FALSE;
   media->invalid = FALSE;
   media->percent_loaded = 0;
   if (media->surface != NULL) {

--- a/src/CbMediaImageWidget.c
+++ b/src/CbMediaImageWidget.c
@@ -94,6 +94,28 @@ cb_media_image_widget_init (CbMediaImageWidget *self)
 }
 
 void
+set_window_size_request (CbMediaImageWidget *self, CbMedia *media) {
+  int win_width;
+  int win_height;
+
+  win_width = media->width;
+  win_height = media->height;
+
+  if (win_width > self->max_width)
+  {
+    win_width = self->max_width;
+  }
+
+  if (win_height > self->max_height)
+  {
+    win_height = self->max_height;
+  }
+
+  g_debug("Setting window size for %s to %d×%d (%d×%d)", media->url, win_width, win_height, media->width, media->height);
+  gtk_widget_set_size_request (GTK_WIDGET (self), win_width, win_height);
+}
+
+void
 hires_progress (CbMedia *media, gpointer user_data) {
   if (!media->loaded_hires) {
     return;
@@ -102,20 +124,22 @@ hires_progress (CbMedia *media, gpointer user_data) {
   gtk_image_set_from_surface (GTK_IMAGE (self->image), media->surface_hires);
   cairo_surface_destroy(self->image_surface);
   self->image_surface = NULL;
+  set_window_size_request(self, media);
 }
 
 GtkWidget *
 cb_media_image_widget_new (CbMedia *media, GdkRectangle *max_dimensions)
 {
   CbMediaImageWidget *self;
-  int win_width;
-  int win_height;
 
   g_return_val_if_fail (CB_IS_MEDIA (media), NULL);
   g_return_val_if_fail (!media->invalid, NULL);
   g_return_val_if_fail (media->surface != NULL, NULL);
 
   self = CB_MEDIA_IMAGE_WIDGET (g_object_new (CB_TYPE_MEDIA_IMAGE_WIDGET, NULL));
+  //memcpy(&self->max_dimensions, &max_dimensions, sizeof(GdkRectangle));
+  self->max_width = max_dimensions->width;
+  self->max_height = max_dimensions->height;
 
   if (media->type == CB_MEDIA_TYPE_GIF) {
     gtk_image_set_from_animation (GTK_IMAGE (self->image), media->animation);
@@ -141,20 +165,7 @@ cb_media_image_widget_new (CbMedia *media, GdkRectangle *max_dimensions)
     }
   }
 
-  win_width = media->width;
-  win_height = media->height;
-
-  if (win_width > max_dimensions->width)
-  {
-    win_width = max_dimensions->width;
-  }
-
-  if (win_height > max_dimensions->height)
-  {
-    win_height = max_dimensions->height;
-  }
-
-  gtk_widget_set_size_request (GTK_WIDGET (self), win_width, win_height);
+  set_window_size_request(self, media);
   gtk_widget_set_tooltip_text (GTK_WIDGET (self), media->alt_text);
   atk_object_set_description(gtk_widget_get_accessible(GTK_WIDGET(self)), media->alt_text == NULL ? "" : media->alt_text);
 

--- a/src/CbMediaImageWidget.h
+++ b/src/CbMediaImageWidget.h
@@ -28,6 +28,8 @@ G_DECLARE_FINAL_TYPE (CbMediaImageWidget, cb_media_image_widget, CB, MEDIA_IMAGE
 struct _CbMediaImageWidget
 {
   GtkScrolledWindow parent_instance;
+  gint max_width;
+  gint max_height;
 
   GtkWidget *image;
   GtkGesture *drag_gesture;

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -350,7 +350,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
   }
 
   private void media_clicked_cb (Cb.Media m, int index, double px, double py) {
-    debug("Media clicked");
     TweetUtils.handle_media_click (this.tweet.get_medias (), this.main_window, index);
   }
 

--- a/src/list/TweetListEntry.vala
+++ b/src/list/TweetListEntry.vala
@@ -190,7 +190,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
       mm_widget.set_all_media (tweet.get_medias ());
       mm_widget.media_clicked.connect (media_clicked_cb);
       mm_widget.media_invalid.connect (media_invalid_cb);
-      mm_widget.window = main_window;
     }
 
     if (tweet.has_quoted_inline_media ()) {
@@ -202,7 +201,6 @@ public class TweetListEntry : Cb.TwitterItem, Gtk.ListBoxRow {
       quoted_mm_widget.set_all_media (tweet.get_quoted_medias ());
       quoted_mm_widget.media_clicked.connect (quoted_media_clicked_cb);
       quoted_mm_widget.media_invalid.connect (quoted_media_invalid_cb);
-      quoted_mm_widget.window = main_window;
     }
 
     if (tweet.has_inline_media () || tweet.has_quoted_inline_media ()) {

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -37,7 +37,6 @@ private class MediaButton : Gtk.Bin {
           _media.progress.connect (media_progress_cb);
         }
         set_save_as_sensitivity();
-        set_image_description();
         if (!is_m3u8 && !_media.requires_authentication()) {
           menu_model.append (_("Copy URL"), "media.copy-url");
         }
@@ -91,7 +90,7 @@ private class MediaButton : Gtk.Bin {
     this.press_gesture.set_button (0);
     this.press_gesture.set_propagation_phase (Gtk.PropagationPhase.CAPTURE);
     this.press_gesture.pressed.connect (gesture_pressed_cb);
-    set_image_description();
+    this.key_release_event.connect(button_pressed_cb);
   }
 
   private void reload_image() {
@@ -183,20 +182,31 @@ private class MediaButton : Gtk.Bin {
 
     if (event.triggers_context_menu ()) {
       this.press_gesture.set_state (Gtk.EventSequenceState.CLAIMED);
-
-      if (this.menu == null) {
-        this.menu = new Gtk.Menu.from_model (menu_model);
-        this.menu.attach_to_widget (this, null);
-      }
-      menu.show_all ();
-      menu.popup_at_pointer (event);
+      show_menu(event);
     }
   }
 
-  private void set_image_description() {
-    if (media != null) {
-      this.set_tooltip_text(media.alt_text);
-      this.get_accessible().set_description(media.alt_text ?? "");
+  private bool button_pressed_cb (Gdk.EventKey event_key) {
+    uint keyval;
+    event_key.get_keyval (out keyval);
+    if (keyval == Gdk.Key.Menu) {
+      show_menu();
+      return Gdk.EVENT_STOP;
+    }
+    return Gdk.EVENT_PROPAGATE;
+  }
+
+  private void show_menu(Gdk.Event? event = null) {
+    if (this.menu == null) {
+      this.menu = new Gtk.Menu.from_model (menu_model);
+      this.menu.attach_to_widget (this, null);
+    }
+    menu.show_all ();
+    if (event != null) {
+      menu.popup_at_pointer (event);
+    }
+    else {
+      menu.popup_at_widget (this, Gdk.Gravity.CENTER, Gdk.Gravity.NORTH_WEST);
     }
   }
 

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -60,7 +60,6 @@ private class MediaButton : Gtk.Bin {
 
   construct {
     this.set_has_window (false);
-    this.set_can_focus (true);
   }
 
   ~MediaButton () {

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -205,4 +205,8 @@ private class MediaButton : Gtk.Bin {
   private void set_save_as_sensitivity() {
     ((GLib.SimpleAction)actions.lookup_action ("save-as")).set_enabled (!_media.invalid && !is_m3u8);
   }
+
+  public override Gtk.SizeRequestMode get_request_mode () {
+    return Gtk.SizeRequestMode.HEIGHT_FOR_WIDTH;
+  }
 }

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -80,7 +80,6 @@ private class MediaButton : Gtk.Bin {
     menu_model.append (_("Save as…"), "media.save-as");
 
     this.media = media;
-    // XXX: Don't create until media is set?
     button_surface = new MediaButtonSurface (this.media, restrict_height);
     button_surface.clicked.connect((surface, x, y) => {
       this.clicked(this, x, y);

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -101,7 +101,7 @@ private class MediaButton : Gtk.Bin {
 
   private void media_progress_cb () {
     if (this._media.loaded) {
-      if (this._media.invalid) {
+      if (this._media.invalid && !this._media.permanent_invalid) {
         Gtk.Button reload_button = new Gtk.Button();
         reload_button.label = _("Reload image");
         reload_button.halign = Gtk.Align.CENTER;

--- a/src/widgets/MediaButton.vala
+++ b/src/widgets/MediaButton.vala
@@ -16,16 +16,9 @@
  */
 
 private class MediaButton : Gtk.Bin {
-  private const int PLAY_ICON_SIZE = 32;
-  private const int MAX_HEIGHT     = 200;
-  /* We use MIN_ constants in case the media has not yet been loaded */
-  private const int MIN_HEIGHT     = 40;
-  private const int MIN_WIDTH      = 40;
-  private Gdk.Window? event_window = null;
   private Cb.Media? _media = null;
-  private static Cairo.Surface[] play_icons;
   private bool is_m3u8 {
-    get { 
+    get {
       // Some URLs have query strings, so we can't just suffix
       return _media.url.contains(".m3u8");
     }
@@ -42,8 +35,6 @@ private class MediaButton : Gtk.Bin {
       if (value != null) {
         if (!media.loaded) {
           _media.progress.connect (media_progress_cb);
-        } else {
-          this.media_alpha = 1.0;
         }
         set_save_as_sensitivity();
         set_image_description();
@@ -53,7 +44,6 @@ private class MediaButton : Gtk.Bin {
       }
     }
   }
-  public unowned Gtk.Window window;
   private GLib.Menu menu_model;
   private Gtk.Menu? menu = null;
   private GLib.SimpleActionGroup actions;
@@ -62,27 +52,11 @@ private class MediaButton : Gtk.Bin {
     {"open-in-browser", open_in_browser_activated},
     {"save-as",         save_as_activated},
   };
-  private Pango.Layout layout;
   private Gtk.GestureMultiPress press_gesture;
   private bool restrict_height = false;
-  private int64 fade_start_time;
-  private double media_alpha = 0.0;
-
+  private MediaButtonSurface button_surface;
 
   public signal void clicked (MediaButton source, double px, double py);
-
-  static construct {
-    try {
-      play_icons = {
-        Gdk.cairo_surface_create_from_pixbuf (
-          new Gdk.Pixbuf.from_resource ("/uk/co/ibboard/cawbird/data/play.png"), 1, null),
-        Gdk.cairo_surface_create_from_pixbuf (
-          new Gdk.Pixbuf.from_resource ("/uk/co/ibboard/cawbird/data/play@2.png"), 2, null),
-      };
-    } catch (GLib.Error e) {
-      critical (e.message);
-    }
-  }
 
   construct {
     this.set_has_window (false);
@@ -97,13 +71,6 @@ private class MediaButton : Gtk.Bin {
 
   public MediaButton (Cb.Media? media, bool restrict_height = false) {
     this.restrict_height = restrict_height;
-    Gtk.Button reload_button = new Gtk.Button();
-    reload_button.label = _("Reload image");
-    reload_button.halign = Gtk.Align.CENTER;
-    reload_button.valign = Gtk.Align.CENTER;
-    this.add(reload_button);
-    reload_button.show();
-    this.get_style_context ().add_class ("inline-media");
     actions = new GLib.SimpleActionGroup ();
     actions.add_action_entries (action_entries, this);
     this.insert_action_group ("media", actions);
@@ -111,18 +78,21 @@ private class MediaButton : Gtk.Bin {
     this.menu_model = new GLib.Menu ();
     menu_model.append (_("Open in Browser"), "media.open-in-browser");
     menu_model.append (_("Save as…"), "media.save-as");
-    
-    this.media = media;
 
-    this.layout = this.create_pango_layout ("0%");
+    this.media = media;
+    // XXX: Don't create until media is set?
+    button_surface = new MediaButtonSurface (this.media, restrict_height);
+    button_surface.clicked.connect((surface, x, y) => {
+      this.clicked(this, x, y);
+    });
+    this.add(button_surface);
+    button_surface.show();
+
     this.press_gesture = new Gtk.GestureMultiPress (this);
     this.press_gesture.set_exclusive (true);
     this.press_gesture.set_button (0);
     this.press_gesture.set_propagation_phase (Gtk.PropagationPhase.CAPTURE);
-    this.press_gesture.released.connect (gesture_released_cb);
     this.press_gesture.pressed.connect (gesture_pressed_cb);
-    this.enter_notify_event.connect(Utils.set_pointer_on_mouseover);
-    this.leave_notify_event.connect(Utils.set_pointer_on_mouseover);
     set_image_description();
   }
 
@@ -131,141 +101,27 @@ private class MediaButton : Gtk.Bin {
   }
 
   private void media_progress_cb () {
-    this.queue_draw ();
-
     if (this._media.loaded) {
-      if (!_media.invalid && _media.surface != null) {
-        this.start_fade ();
+      if (this._media.invalid) {
+        Gtk.Button reload_button = new Gtk.Button();
+        reload_button.label = _("Reload image");
+        reload_button.halign = Gtk.Align.CENTER;
+        reload_button.valign = Gtk.Align.CENTER;
+        reload_button.clicked.connect(reload_image);
+        if (get_child() == button_surface) {
+          remove(button_surface);
+          add(reload_button);
+        }
+        reload_button.show();
+      }
+      else if (get_child() != button_surface) {
+        remove(get_child());
+        add(button_surface);
       }
 
       set_save_as_sensitivity();
       this.queue_resize ();
     }
-  }
-
-  private bool fade_in_cb (Gtk.Widget widget, Gdk.FrameClock frame_clock) {
-    if (!this.get_mapped ()) {
-      this.media_alpha = 1.0;
-      return GLib.Source.REMOVE;
-    }
-
-    int64 now = frame_clock.get_frame_time ();
-    double t = 1.0;
-    if (now < this.fade_start_time + TRANSITION_DURATION)
-      t = (now - fade_start_time) / (double)(TRANSITION_DURATION );
-
-    t = ease_out_cubic (t);
-
-    this.media_alpha = t;
-    this.queue_draw ();
-    if (t >= 1.0) {
-      this.media_alpha = 1.0;
-      return GLib.Source.REMOVE;
-    }
-
-    return GLib.Source.CONTINUE;
-  }
-
-  private void start_fade () {
-    assert (this.media != null);
-    assert (this.media.surface != null);
-
-    if (!this.get_realized () || !this.get_mapped () ||
-        !Gtk.Settings.get_default ().gtk_enable_animations) {
-      this.media_alpha = 1.0;
-      return;
-    }
-
-    this.fade_start_time = this.get_frame_clock ().get_frame_time ();
-    this.add_tick_callback (fade_in_cb);
-  }
-
-  public override bool draw (Cairo.Context ct) {
-    int widget_width = get_allocated_width ();
-    int widget_height = get_allocated_height ();
-
-    if (_media != null && _media.invalid) {
-      base.draw(ct);
-    }
-    else if (_media != null && _media.surface != null && _media.loaded) {
-      /* Draw thumbnail */
-      int draw_x, draw_y;
-      double scale;
-      Utils.calculate_draw_offset (_media.thumb_width, _media.thumb_height,
-                                   get_allocated_width(), get_allocated_height(),
-                                   out draw_x, out draw_y, out scale);
-
-      var draw_width = get_allocated_width() - draw_x;
-      var draw_height = get_allocated_height() - draw_y;
-
-      ct.save ();
-      ct.rectangle (0, 0, widget_width, widget_height);
-      ct.scale (scale, scale);
-      ct.set_source_surface (media.surface, draw_x / scale, draw_y / scale);
-      ct.paint_with_alpha (this.media_alpha);
-      ct.restore ();
-      ct.new_path ();
-
-      /*
-       * If image got moved off the top, we cropped it. Indicate that.
-       * Currently trying a gradient overlay top and bottom
-       */
-      if (draw_y < 0) {
-        Cairo.Pattern pattern = new Cairo.Pattern.linear (0.0, 0.0, 0, widget_height);
-        pattern.add_color_stop_rgba (0.01, 0.3, 0.3, 0.3, 1);
-        pattern.add_color_stop_rgba (0.1, 0.7, 0.7, 0.7, 0);
-        pattern.add_color_stop_rgba (0.9, 0.7, 0.7, 0.7, 0);
-        pattern.add_color_stop_rgba (0.99, 0.3, 0.3, 0.3, 1);
-        ct.rectangle (0, 0, widget_width, widget_height);
-        ct.set_source (pattern);
-        ct.fill ();
-      }
-
-      /* Draw play indicator */
-      if (_media.is_video ()) {
-        int x = (widget_width  / 2) - (PLAY_ICON_SIZE / 2);
-        int y = (widget_height / 2) - (PLAY_ICON_SIZE / 2);
-
-        ct.save ();
-        ct.rectangle (x, y, PLAY_ICON_SIZE, PLAY_ICON_SIZE);
-        ct.set_source_surface (play_icons[this.get_scale_factor () == 1 ? 0 : 1], x, y);
-        ct.paint_with_alpha (this.media_alpha);
-        ct.restore ();
-        ct.new_path ();
-      }
-
-      if (media.alt_text != null && media.alt_text != "") {
-        Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default();
-        int icon_size = 24;
-        try {
-          Gdk.Pixbuf pixbuf = icon_theme.load_icon_for_scale ("dialog-information", icon_size, this.get_scale_factor(), Gtk.IconLookupFlags.USE_BUILTIN);
-          var icon = Gdk.cairo_surface_create_from_pixbuf (pixbuf, this.get_scale_factor(), null);
-          ct.set_source_surface (icon, draw_x / scale, widget_height - icon_size * this.get_scale_factor());
-          ct.paint();
-        } catch (GLib.Error e) {
-          warning(e.message);
-        }
-      }
-
-      var sc = this.get_style_context ();
-      sc.render_background (ct, draw_x, 0, draw_width, draw_height);
-      sc.render_frame      (ct, draw_x, 0, draw_width, draw_height);
-
-      if (this.has_visible_focus ()) {
-        sc.render_focus (ct, draw_x + 2, 2, draw_width - 4, draw_height - 4);
-      }
-    } else {
-      var sc = this.get_style_context ();
-      double layout_x, layout_y;
-      int layout_w, layout_h;
-      layout.set_text ("%d%%".printf ((int)(_media.percent_loaded * 100)), -1);
-      layout.get_size (out layout_w, out layout_h);
-      layout_x = (widget_width / 2.0) - (layout_w / Pango.SCALE / 2.0);
-      layout_y = (widget_height / 2.0) - (layout_h / Pango.SCALE / 2.0);
-      sc.render_layout (ct, layout_x, layout_y, layout);
-    }
-
-    return Gdk.EVENT_PROPAGATE;
   }
 
   private void copy_url_activated (GLib.SimpleAction a, GLib.Variant? v) {
@@ -290,7 +146,7 @@ private class MediaButton : Gtk.Bin {
       title = _("Save Image");
 
     var filechooser = new Gtk.FileChooserNative (title,
-                                                 this.window,
+                                                 (Gtk.Window)get_toplevel(),
                                                  Gtk.FileChooserAction.SAVE,
                                                  _("Save"),
                                                  _("Cancel"));
@@ -306,7 +162,7 @@ private class MediaButton : Gtk.Bin {
       try {
         out_stream = file.create (0, null);
       } catch (GLib.Error e) {
-        Utils.show_error_dialog (e, this.window);
+        Utils.show_error_dialog (e, (Gtk.Window)get_toplevel());
         warning (e.message);
       }
 
@@ -316,173 +172,6 @@ private class MediaButton : Gtk.Bin {
         });
       }
     }
-  }
-
-  public override Gtk.SizeRequestMode get_request_mode () {
-    return Gtk.SizeRequestMode.HEIGHT_FOR_WIDTH;
-  }
-
-  public override void get_preferred_height (out int minimum,
-                                             out int natural) {
-    int media_height;
-    if (this._media == null || this._media.thumb_height == -1) {
-      media_height = 1;
-    } else {
-      media_height = this._media.thumb_height;
-    }
-
-    if (restrict_height) {
-      minimum = int.min (media_height, MAX_HEIGHT);
-    }
-    else {
-      minimum = media_height;
-    }
-
-    natural = media_height;
-  }
-
-  public override void get_preferred_height_for_width (int width,
-                                                       out int minimum,
-                                                       out int natural) {
-    int media_width;
-    int media_height;
-    
-    if (this._media == null || this._media.thumb_width == -1 || this._media.thumb_height == -1) {
-      media_width = MIN_WIDTH;
-      media_height = MAX_HEIGHT;
-    } else {
-      media_width = this._media.thumb_width;
-      media_height = this._media.thumb_height;
-    }
-
-    double scale = width / (double) media_width;
-    
-    int height = 0;
-
-    if (scale >= 1) {
-      height = int.min (media_height, (int) Math.floor ((width / 9.0) * 16));
-    } else {
-      height = (int) Math.floor (double.min (media_height * scale, (media_width * scale / 9.0) * 16));
-    }
-
-    if (restrict_height) {
-      height = int.min (height, MAX_HEIGHT);
-    }
-
-    minimum = natural = height;
-  }
-
-  public override void get_preferred_width_for_height (int height,
-                                                       out int minimum,
-                                                       out int natural) {
-    int media_width;
-    int media_height;
-
-    if (this._media == null || this._media.thumb_width == -1 || this._media.thumb_height == -1) {
-      media_width = MIN_WIDTH;
-      media_height = MAX_HEIGHT;
-    } else {
-      media_width = this._media.thumb_width;
-      media_height = this._media.thumb_height;
-    }
-
-    int max_width = (int) Math.floor ((height / 16.0) * 9);
-    int width = int.min (media_width, max_width);
-    minimum = MIN_WIDTH;
-    natural = int.max (width, minimum);
-  }
-
-  public override void get_preferred_width (out int minimum,
-                                            out int natural) {
-    int media_width;
-    if (this._media == null || this._media.thumb_width == -1) {
-      media_width = 1;
-    } else {
-      media_width = this._media.thumb_width;
-    }
-
-    minimum = int.min (media_width, MIN_WIDTH);
-    natural = media_width;
-  }
-
-  public override void realize () {
-    this.set_realized (true);
-
-    Gdk.WindowAttr attr = {};
-    attr.x = 0;
-    attr.y = 0;
-    attr.width = get_allocated_width();
-    attr.height = get_allocated_height();
-    attr.window_type = Gdk.WindowType.CHILD;
-    attr.visual = this.get_visual ();
-    attr.wclass = Gdk.WindowWindowClass.INPUT_ONLY;
-    attr.event_mask = this.get_events () |
-                      Gdk.EventMask.BUTTON_PRESS_MASK |
-                      Gdk.EventMask.BUTTON_RELEASE_MASK |
-                      Gdk.EventMask.TOUCH_MASK |
-                      Gdk.EventMask.ENTER_NOTIFY_MASK |
-                      Gdk.EventMask.LEAVE_NOTIFY_MASK;
-
-    Gdk.WindowAttributesType attr_mask = Gdk.WindowAttributesType.X |
-                                         Gdk.WindowAttributesType.Y;
-    Gdk.Window window = this.get_parent_window ();
-    this.set_window (window);
-    window.ref ();
-
-    this.event_window = new Gdk.Window (window, attr, attr_mask);
-    this.register_window (this.event_window);
-  }
-
-  public override void unrealize () {
-    if (this.event_window != null) {
-      this.unregister_window (this.event_window);
-      this.event_window.destroy ();
-      this.event_window = null;
-    }
-    base.unrealize ();
-  }
-
-  public override void map () {
-    base.map ();
-
-    if (this.event_window != null)
-      this.event_window.show ();
-  }
-
-  public override void unmap () {
-
-    if (this.event_window != null)
-      this.event_window.hide ();
-
-    base.unmap ();
-  }
-
-  public override void size_allocate (Gtk.Allocation alloc) {
-    base.size_allocate (alloc);
-
-    if (this.get_realized ()) {
-      this.event_window.move_resize (alloc.x, alloc.y, alloc.width, alloc.height);
-    }
-  }
-
-  public override bool enter_notify_event (Gdk.EventCrossing evt) {
-    if (evt.window == this.event_window &&
-        evt.detail != Gdk.NotifyType.INFERIOR) {
-      this.set_state_flags (this.get_state_flags () | Gtk.StateFlags.PRELIGHT,
-                            true);
-    }
-
-    return Gdk.EVENT_PROPAGATE;
-  }
-
-  public override bool leave_notify_event (Gdk.EventCrossing evt) {
-    if (evt.window == this.event_window &&
-        evt.detail != Gdk.NotifyType.INFERIOR) {
-      this.set_state_flags (this.get_state_flags () & ~Gtk.StateFlags.PRELIGHT,
-                            true);
-    }
-
-    return Gdk.EVENT_PROPAGATE;
   }
 
   private void gesture_pressed_cb (int    n_press,
@@ -506,44 +195,6 @@ private class MediaButton : Gtk.Bin {
     }
   }
 
-  private void gesture_released_cb (int    n_press,
-                                    double x,
-                                    double y) {
-    Gdk.EventSequence sequence = this.press_gesture.get_current_sequence ();
-    Gdk.Event event = this.press_gesture.get_last_event (sequence);
-    uint button = this.press_gesture.get_current_button ();
-
-    if (this._media == null || event == null)
-      return;
-
-    if (button == Gdk.BUTTON_PRIMARY) {
-      this.press_gesture.set_state (Gtk.EventSequenceState.CLAIMED);
-      if (_media.invalid) {
-        reload_image();
-      }
-      else {
-        double px = x / (double)this.get_allocated_width ();
-        double py = y / (double)this.get_allocated_height ();
-        this.clicked (this, px, py);
-      }
-    }
-  }
-
-  public override bool key_press_event (Gdk.EventKey event) {
-    if (event.keyval == Gdk.Key.Return ||
-        event.keyval == Gdk.Key.KP_Enter) {
-      if (_media.invalid) {
-        reload_image();
-      }
-      else {
-        this.clicked (this, 0.5, 0.5);
-      }
-      return Gdk.EVENT_STOP;
-    }
-
-    return Gdk.EVENT_PROPAGATE;
-  }
-
   private void set_image_description() {
     if (media != null) {
       this.set_tooltip_text(media.alt_text);
@@ -552,6 +203,6 @@ private class MediaButton : Gtk.Bin {
   }
 
   private void set_save_as_sensitivity() {
-    ((GLib.SimpleAction)actions.lookup_action ("save-as")).set_enabled (!_media.invalid && !is_m3u8);    
+    ((GLib.SimpleAction)actions.lookup_action ("save-as")).set_enabled (!_media.invalid && !is_m3u8);
   }
 }

--- a/src/widgets/MediaButtonSurface.vala
+++ b/src/widgets/MediaButtonSurface.vala
@@ -244,7 +244,6 @@
       }
 
       natural = media_height;
-      debug("Preferred height: %d, %d", natural, minimum);
     }
 
     public override void get_preferred_height_for_width (int width,
@@ -276,7 +275,6 @@
       }
 
       minimum = natural = height;
-      debug("Preferred height for width %d: %d, %d", width, natural, minimum);
     }
 
     public override void get_preferred_width_for_height (int height,
@@ -297,7 +295,6 @@
       int width = int.min (media_width, max_width);
       minimum = MIN_WIDTH;
       natural = int.max (width, minimum);
-      debug("Preferred width for height %d: %d, %d", height, natural, minimum);
     }
 
     public override void get_preferred_width (out int minimum,
@@ -311,7 +308,6 @@
 
       minimum = int.min (media_width, MIN_WIDTH);
       natural = media_width;
-      debug("Preferred width: %d, %d", natural, minimum);
     }
 
     public override void realize () {

--- a/src/widgets/MediaButtonSurface.vala
+++ b/src/widgets/MediaButtonSurface.vala
@@ -1,0 +1,424 @@
+/*  This file is part of Cawbird, a Gtk+ linux Twitter client forked from Corebird.
+ *  Copyright (C) 2013 Timm Bäder (Corebird)
+ *
+ *  Cawbird is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Cawbird is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with cawbird.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ private class MediaButtonSurface : Gtk.Widget {
+    private const int PLAY_ICON_SIZE = 32;
+    private const int MAX_HEIGHT     = 200;
+    /* We use MIN_ constants in case the media has not yet been loaded */
+    private const int MIN_WIDTH      = 40;
+    private Gdk.Window? event_window = null;
+    private Cb.Media? _media = null;
+    private static Cairo.Surface[] play_icons;
+    public Cb.Media? media {
+      get {
+        return _media;
+      }
+      set {
+        if (_media != null) {
+          _media.progress.disconnect (media_progress_cb);
+        }
+        _media = value;
+        if (value != null) {
+          if (!media.loaded) {
+            _media.progress.connect (media_progress_cb);
+          } else {
+            this.media_alpha = 1.0;
+          }
+        }
+      }
+    }
+    private Pango.Layout layout;
+    private Gtk.GestureMultiPress press_gesture;
+    private bool restrict_height = false;
+    private int64 fade_start_time;
+    private double media_alpha = 0.0;
+
+    public signal void clicked (MediaButtonSurface source, double px, double py);
+
+    static construct {
+      try {
+        play_icons = {
+          Gdk.cairo_surface_create_from_pixbuf (
+            new Gdk.Pixbuf.from_resource ("/uk/co/ibboard/cawbird/data/play.png"), 1, null),
+          Gdk.cairo_surface_create_from_pixbuf (
+            new Gdk.Pixbuf.from_resource ("/uk/co/ibboard/cawbird/data/play@2.png"), 2, null),
+        };
+      } catch (GLib.Error e) {
+        critical (e.message);
+      }
+    }
+
+    construct {
+      this.set_has_window (false);
+    }
+
+    ~MediaButtonSurface () {
+      if (_media != null) {
+        _media.progress.disconnect (media_progress_cb);
+      }
+    }
+
+    public MediaButtonSurface (Cb.Media? media, bool restrict_height = false) {
+      this.media = media;
+      this.restrict_height = restrict_height;
+      this.get_style_context ().add_class ("inline-media");
+
+      this.layout = this.create_pango_layout ("0%");
+      this.press_gesture = new Gtk.GestureMultiPress (this);
+      this.press_gesture.set_exclusive (true);
+      this.press_gesture.set_button (0);
+      this.press_gesture.released.connect (gesture_released_cb);
+      this.enter_notify_event.connect(Utils.set_pointer_on_mouseover);
+      this.leave_notify_event.connect(Utils.set_pointer_on_mouseover);
+    }
+
+    private void media_progress_cb () {
+      this.queue_draw ();
+
+      if (this._media.loaded) {
+        if (!_media.invalid && _media.surface != null) {
+          this.start_fade ();
+        }
+
+        this.queue_resize ();
+      }
+    }
+
+    private bool fade_in_cb (Gtk.Widget widget, Gdk.FrameClock frame_clock) {
+      if (!this.get_mapped ()) {
+        this.media_alpha = 1.0;
+        return GLib.Source.REMOVE;
+      }
+
+      int64 now = frame_clock.get_frame_time ();
+      double t = 1.0;
+      if (now < this.fade_start_time + TRANSITION_DURATION)
+        t = (now - fade_start_time) / (double)(TRANSITION_DURATION );
+
+      t = ease_out_cubic (t);
+
+      this.media_alpha = t;
+      this.queue_draw ();
+      if (t >= 1.0) {
+        this.media_alpha = 1.0;
+        return GLib.Source.REMOVE;
+      }
+
+      return GLib.Source.CONTINUE;
+    }
+
+    private void start_fade () {
+      assert (this.media != null);
+      assert (this.media.surface != null);
+
+      if (!this.get_realized () || !this.get_mapped () ||
+          !Gtk.Settings.get_default ().gtk_enable_animations) {
+        this.media_alpha = 1.0;
+        return;
+      }
+
+      this.fade_start_time = this.get_frame_clock ().get_frame_time ();
+      this.add_tick_callback (fade_in_cb);
+    }
+
+    public override bool draw (Cairo.Context ct) {
+      int widget_width = get_allocated_width ();
+      int widget_height = get_allocated_height ();
+
+      if (_media != null && _media.invalid) {
+        return base.draw(ct);
+      }
+      else if (_media != null && _media.surface != null && _media.loaded) {
+        /* Draw thumbnail */
+        int draw_x, draw_y;
+        double scale;
+        Utils.calculate_draw_offset (_media.thumb_width, _media.thumb_height,
+                                     get_allocated_width(), get_allocated_height(),
+                                     out draw_x, out draw_y, out scale);
+
+        var draw_width = get_allocated_width() - draw_x;
+        var draw_height = get_allocated_height() - draw_y;
+
+        ct.save ();
+        ct.rectangle (0, 0, widget_width, widget_height);
+        ct.scale (scale, scale);
+        ct.set_source_surface (media.surface, draw_x / scale, draw_y / scale);
+        ct.paint_with_alpha (this.media_alpha);
+        ct.restore ();
+        ct.new_path ();
+
+        /*
+         * If image got moved off the top, we cropped it. Indicate that.
+         * Currently trying a gradient overlay top and bottom
+         */
+        if (draw_y < 0) {
+          Cairo.Pattern pattern = new Cairo.Pattern.linear (0.0, 0.0, 0, widget_height);
+          pattern.add_color_stop_rgba (0.01, 0.3, 0.3, 0.3, 1);
+          pattern.add_color_stop_rgba (0.1, 0.7, 0.7, 0.7, 0);
+          pattern.add_color_stop_rgba (0.9, 0.7, 0.7, 0.7, 0);
+          pattern.add_color_stop_rgba (0.99, 0.3, 0.3, 0.3, 1);
+          ct.rectangle (0, 0, widget_width, widget_height);
+          ct.set_source (pattern);
+          ct.fill ();
+        }
+
+        /* Draw play indicator */
+        if (_media.is_video ()) {
+          int x = (widget_width  / 2) - (PLAY_ICON_SIZE / 2);
+          int y = (widget_height / 2) - (PLAY_ICON_SIZE / 2);
+
+          ct.save ();
+          ct.rectangle (x, y, PLAY_ICON_SIZE, PLAY_ICON_SIZE);
+          ct.set_source_surface (play_icons[this.get_scale_factor () == 1 ? 0 : 1], x, y);
+          ct.paint_with_alpha (this.media_alpha);
+          ct.restore ();
+          ct.new_path ();
+        }
+
+        if (media.alt_text != null && media.alt_text != "") {
+          Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default();
+          int icon_size = 24;
+          try {
+            Gdk.Pixbuf pixbuf = icon_theme.load_icon_for_scale ("dialog-information", icon_size, this.get_scale_factor(), Gtk.IconLookupFlags.USE_BUILTIN);
+            var icon = Gdk.cairo_surface_create_from_pixbuf (pixbuf, this.get_scale_factor(), null);
+            ct.set_source_surface (icon, draw_x / scale, widget_height - icon_size * this.get_scale_factor());
+            ct.paint();
+          } catch (GLib.Error e) {
+            warning(e.message);
+          }
+        }
+
+        var sc = this.get_style_context ();
+        sc.render_background (ct, draw_x, 0, draw_width, draw_height);
+        sc.render_frame      (ct, draw_x, 0, draw_width, draw_height);
+
+        if (this.has_visible_focus ()) {
+          sc.render_focus (ct, draw_x + 2, 2, draw_width - 4, draw_height - 4);
+        }
+      } else {
+        var sc = this.get_style_context ();
+        double layout_x, layout_y;
+        int layout_w, layout_h;
+        layout.set_text ("%d%%".printf ((int)(_media.percent_loaded * 100)), -1);
+        layout.get_size (out layout_w, out layout_h);
+        layout_x = (widget_width / 2.0) - (layout_w / Pango.SCALE / 2.0);
+        layout_y = (widget_height / 2.0) - (layout_h / Pango.SCALE / 2.0);
+        sc.render_layout (ct, layout_x, layout_y, layout);
+      }
+
+      return Gdk.EVENT_PROPAGATE;
+    }
+
+    public override Gtk.SizeRequestMode get_request_mode () {
+      return Gtk.SizeRequestMode.HEIGHT_FOR_WIDTH;
+    }
+
+    public override void get_preferred_height (out int minimum,
+                                               out int natural) {
+      int media_height;
+      if (this._media == null || this._media.thumb_height == -1) {
+        media_height = 1;
+      } else {
+        media_height = this._media.thumb_height;
+      }
+
+      if (restrict_height) {
+        minimum = int.min (media_height, MAX_HEIGHT);
+      }
+      else {
+        minimum = media_height;
+      }
+
+      natural = media_height;
+      debug("Preferred height: %d, %d", natural, minimum);
+    }
+
+    public override void get_preferred_height_for_width (int width,
+                                                         out int minimum,
+                                                         out int natural) {
+      int media_width;
+      int media_height;
+
+      if (this._media == null || this._media.thumb_width == -1 || this._media.thumb_height == -1) {
+        media_width = MIN_WIDTH;
+        media_height = MAX_HEIGHT;
+      } else {
+        media_width = this._media.thumb_width;
+        media_height = this._media.thumb_height;
+      }
+
+      double scale = width / (double) media_width;
+
+      int height = 0;
+
+      if (scale >= 1) {
+        height = int.min (media_height, (int) Math.floor ((width / 9.0) * 16));
+      } else {
+        height = (int) Math.floor (double.min (media_height * scale, (media_width * scale / 9.0) * 16));
+      }
+
+      if (restrict_height) {
+        height = int.min (height, MAX_HEIGHT);
+      }
+
+      minimum = natural = height;
+      debug("Preferred height for width %d: %d, %d", width, natural, minimum);
+    }
+
+    public override void get_preferred_width_for_height (int height,
+                                                         out int minimum,
+                                                         out int natural) {
+      int media_width;
+      int media_height;
+
+      if (this._media == null || this._media.thumb_width == -1 || this._media.thumb_height == -1) {
+        media_width = MIN_WIDTH;
+        media_height = MAX_HEIGHT;
+      } else {
+        media_width = this._media.thumb_width;
+        media_height = this._media.thumb_height;
+      }
+
+      int max_width = (int) Math.floor ((height / 16.0) * 9);
+      int width = int.min (media_width, max_width);
+      minimum = MIN_WIDTH;
+      natural = int.max (width, minimum);
+      debug("Preferred width for height %d: %d, %d", height, natural, minimum);
+    }
+
+    public override void get_preferred_width (out int minimum,
+                                              out int natural) {
+      int media_width;
+      if (this._media == null || this._media.thumb_width == -1) {
+        media_width = 1;
+      } else {
+        media_width = this._media.thumb_width;
+      }
+
+      minimum = int.min (media_width, MIN_WIDTH);
+      natural = media_width;
+      debug("Preferred width: %d, %d", natural, minimum);
+    }
+
+    public override void realize () {
+      this.set_realized (true);
+
+      Gdk.WindowAttr attr = {};
+      attr.x = 0;
+      attr.y = 0;
+      attr.width = get_allocated_width();
+      attr.height = get_allocated_height();
+      attr.window_type = Gdk.WindowType.CHILD;
+      attr.visual = this.get_visual ();
+      attr.wclass = Gdk.WindowWindowClass.INPUT_ONLY;
+      attr.event_mask = this.get_events () |
+                        Gdk.EventMask.BUTTON_PRESS_MASK |
+                        Gdk.EventMask.BUTTON_RELEASE_MASK |
+                        Gdk.EventMask.TOUCH_MASK |
+                        Gdk.EventMask.ENTER_NOTIFY_MASK |
+                        Gdk.EventMask.LEAVE_NOTIFY_MASK;
+
+      Gdk.WindowAttributesType attr_mask = Gdk.WindowAttributesType.X |
+                                           Gdk.WindowAttributesType.Y;
+      Gdk.Window window = this.get_parent_window ();
+      this.set_window (window);
+      window.ref ();
+
+      this.event_window = new Gdk.Window (window, attr, attr_mask);
+      this.register_window (this.event_window);
+    }
+
+    public override void unrealize () {
+      if (this.event_window != null) {
+        this.unregister_window (this.event_window);
+        this.event_window.destroy ();
+        this.event_window = null;
+      }
+      base.unrealize ();
+    }
+
+    public override void map () {
+      base.map ();
+
+      if (this.event_window != null)
+        this.event_window.show ();
+    }
+
+    public override void unmap () {
+
+      if (this.event_window != null)
+        this.event_window.hide ();
+
+      base.unmap ();
+    }
+
+    public override void size_allocate (Gtk.Allocation alloc) {
+      base.size_allocate (alloc);
+
+      if (this.get_realized ()) {
+        this.event_window.move_resize (alloc.x, alloc.y, alloc.width, alloc.height);
+      }
+    }
+
+    public override bool enter_notify_event (Gdk.EventCrossing evt) {
+      if (evt.window == this.event_window &&
+          evt.detail != Gdk.NotifyType.INFERIOR) {
+        this.set_state_flags (this.get_state_flags () | Gtk.StateFlags.PRELIGHT,
+                              true);
+      }
+
+      return Gdk.EVENT_PROPAGATE;
+    }
+
+    public override bool leave_notify_event (Gdk.EventCrossing evt) {
+      if (evt.window == this.event_window &&
+          evt.detail != Gdk.NotifyType.INFERIOR) {
+        this.set_state_flags (this.get_state_flags () & ~Gtk.StateFlags.PRELIGHT,
+                              true);
+      }
+
+      return Gdk.EVENT_PROPAGATE;
+    }
+
+    private void gesture_released_cb (int    n_press,
+                                      double x,
+                                      double y) {
+      Gdk.EventSequence sequence = this.press_gesture.get_current_sequence ();
+      Gdk.Event event = this.press_gesture.get_last_event (sequence);
+      uint button = this.press_gesture.get_current_button ();
+
+      if (this._media == null || event == null)
+        return;
+
+      if (button == Gdk.BUTTON_PRIMARY) {
+        this.press_gesture.set_state (Gtk.EventSequenceState.CLAIMED);
+        double px = x / (double)this.get_allocated_width ();
+        double py = y / (double)this.get_allocated_height ();
+        this.clicked (this, px, py);
+      }
+    }
+
+    public override bool key_press_event (Gdk.EventKey event) {
+      if (event.keyval == Gdk.Key.Return ||
+          event.keyval == Gdk.Key.KP_Enter) {
+        this.clicked (this, 0.5, 0.5);
+        return Gdk.EVENT_STOP;
+      }
+
+      return Gdk.EVENT_PROPAGATE;
+    }
+  }

--- a/src/widgets/MediaButtonSurface.vala
+++ b/src/widgets/MediaButtonSurface.vala
@@ -35,6 +35,7 @@
         }
         _media = value;
         if (value != null) {
+          set_image_description();
           if (!media.loaded) {
             _media.progress.connect (media_progress_cb);
           } else {
@@ -85,6 +86,8 @@
       this.press_gesture.set_exclusive (true);
       this.press_gesture.set_button (0);
       this.press_gesture.released.connect (gesture_released_cb);
+      this.set_accessible_role(Atk.Role.IMAGE);
+      set_image_description();
     }
 
     private void media_progress_cb () {
@@ -432,5 +435,12 @@
       }
 
       return Gdk.EVENT_PROPAGATE;
+    }
+
+    private void set_image_description() {
+      if (media != null) {
+        this.set_tooltip_text(media.alt_text);
+        this.get_accessible().set_description(media.alt_text ?? "");
+      }
     }
   }

--- a/src/widgets/MediaButtonSurface.vala
+++ b/src/widgets/MediaButtonSurface.vala
@@ -65,6 +65,7 @@
     }
 
     construct {
+      this.set_can_focus (true);
       this.set_has_window (false);
     }
 

--- a/src/widgets/MediaButtonSurface.vala
+++ b/src/widgets/MediaButtonSurface.vala
@@ -19,7 +19,9 @@
     private const int PLAY_ICON_SIZE = 32;
     private const int MAX_HEIGHT     = 200;
     /* We use MIN_ constants in case the media has not yet been loaded */
-    private const int MIN_WIDTH      = 40;
+    private const int ICON_SIZE      = 48;
+    private const int MIN_WIDTH      = ICON_SIZE;
+    private const int MIN_HEIGHT     = ICON_SIZE;
     private Gdk.Window? event_window = null;
     private Cb.Media? _media = null;
     private static Cairo.Surface[] play_icons;
@@ -140,7 +142,20 @@
       int widget_height = get_allocated_height ();
 
       if (_media != null && _media.invalid) {
-        return base.draw(ct);
+        if (_media.permanent_invalid) {
+          Gtk.IconTheme icon_theme = Gtk.IconTheme.get_default();
+          try {
+            Gdk.Pixbuf pixbuf = icon_theme.load_icon_for_scale ("image-missing", ICON_SIZE, this.get_scale_factor(), Gtk.IconLookupFlags.USE_BUILTIN);
+            var icon = Gdk.cairo_surface_create_from_pixbuf (pixbuf, this.get_scale_factor(), null);
+            ct.set_source_surface (icon, 0, 0);
+            ct.paint();
+          } catch (GLib.Error e) {
+            warning(e.message);
+          }
+        }
+        else {
+          return base.draw(ct);
+        }
       }
       else if (_media != null && _media.surface != null && _media.loaded) {
         /* Draw thumbnail */
@@ -231,7 +246,7 @@
                                                out int natural) {
       int media_height;
       if (this._media == null || this._media.thumb_height == -1) {
-        media_height = 1;
+        media_height = MIN_HEIGHT;
       } else {
         media_height = this._media.thumb_height;
       }
@@ -254,7 +269,7 @@
 
       if (this._media == null || this._media.thumb_width == -1 || this._media.thumb_height == -1) {
         media_width = MIN_WIDTH;
-        media_height = MAX_HEIGHT;
+        media_height = MIN_HEIGHT;
       } else {
         media_width = this._media.thumb_width;
         media_height = this._media.thumb_height;
@@ -285,7 +300,7 @@
 
       if (this._media == null || this._media.thumb_width == -1 || this._media.thumb_height == -1) {
         media_width = MIN_WIDTH;
-        media_height = MAX_HEIGHT;
+        media_height = MIN_HEIGHT;
       } else {
         media_width = this._media.thumb_width;
         media_height = this._media.thumb_height;
@@ -301,7 +316,7 @@
                                               out int natural) {
       int media_width;
       if (this._media == null || this._media.thumb_width == -1) {
-        media_width = 1;
+        media_width = MIN_WIDTH;
       } else {
         media_width = this._media.thumb_width;
       }
@@ -397,7 +412,7 @@
       Gdk.Event event = this.press_gesture.get_last_event (sequence);
       uint button = this.press_gesture.get_current_button ();
 
-      if (this._media == null || event == null)
+      if (this._media == null || this._media.invalid || event == null)
         return;
 
       if (button == Gdk.BUTTON_PRIMARY) {

--- a/src/widgets/MediaButtonSurface.vala
+++ b/src/widgets/MediaButtonSurface.vala
@@ -84,8 +84,6 @@
       this.press_gesture.set_exclusive (true);
       this.press_gesture.set_button (0);
       this.press_gesture.released.connect (gesture_released_cb);
-      this.enter_notify_event.connect(Utils.set_pointer_on_mouseover);
-      this.leave_notify_event.connect(Utils.set_pointer_on_mouseover);
     }
 
     private void media_progress_cb () {
@@ -94,6 +92,8 @@
       if (this._media.loaded) {
         if (!_media.invalid && _media.surface != null) {
           this.start_fade ();
+          this.enter_notify_event.connect(Utils.set_pointer_on_mouseover);
+          this.leave_notify_event.connect(Utils.set_pointer_on_mouseover);
         }
 
         this.queue_resize ();

--- a/src/widgets/MultiMediaWidget.vala
+++ b/src/widgets/MultiMediaWidget.vala
@@ -27,7 +27,6 @@ public class MultiMediaWidget : Gtk.Box {
       this.set_size_request(-1, value ? MAX_HEIGHT : -1);
     }
   }
-  public unowned Gtk.Window window;
   private MediaButton[] media_buttons;
   private int media_count = 0;
 
@@ -81,17 +80,13 @@ public class MultiMediaWidget : Gtk.Box {
     if (media.loaded && media.invalid)
       return;
 
-    var button = new MediaButton (null, this.restrict_height);
+    var button = new MediaButton (media, this.restrict_height);
     button.set_data ("pos", index);
-    button.window = this.window;
     button.halign = Gtk.Align.CENTER;
     button.valign = Gtk.Align.END;
     media_buttons[index] = button;
 
-    if (media.loaded) {
-      media_buttons[index].media = media;
-    } else {
-      media_buttons[index].media = media;
+    if (!media.loaded) {
       media.progress.connect (media_loaded_cb);
 
       if (!media.loading && this.visible) {

--- a/vapi/cawbird-internal.vapi
+++ b/vapi/cawbird-internal.vapi
@@ -62,6 +62,7 @@ namespace Cb {
     public bool loading_hires;
     public bool loaded_hires;
     public bool invalid;
+    public bool permanent_invalid;
     public string consumer_key;
     public string consumer_secret;
     public string token;

--- a/vapi/cawbird-internal.vapi
+++ b/vapi/cawbird-internal.vapi
@@ -82,6 +82,7 @@ namespace Cb {
     public Cairo.ImageSurface? surface_hires;
     public Gdk.PixbufAnimation? animation;
     public signal void progress();
+    public signal void hires_progress();
 
     public Media();
     public bool is_video ();


### PR DESCRIPTION
Fixed a few related things here:

* Restructured code so that GTK doesn't get confused about gestures vs events and stops the click bubbling through to a single-click activate on the row, and so that button actually clicks
* Differentiate permanent failure from temporary failure and added "broken image" for permanent failure
* Fixed Instagram image loading
* Changed image loading so that high res images that we don't know dimensions of in advance (e.g. Instagram) use a spinner while loading